### PR TITLE
Update dependencies and cross build for 2.12 and 2.13.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,22 +12,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        jdk: [graalvm@19.2.1, adopt@1.11]
+        jdk: [graalvm@21.1.0, adopt@1.11]
     name: Test ${{ matrix.os }} -- ${{ matrix.jdk }}
     steps:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v12
         with:
           java-version: ${{ matrix.jdk }}
-      - uses: actions/setup-node@v1
-        with:
-          node-version: "10.x"
       - name: Set up environment
         run: |
           curl -Lo coursier https://git.io/coursier-cli && chmod +x coursier && ./coursier --help
-          yarn --help
           java -version
         shell: bash
       - name: Check formatting
@@ -37,5 +33,5 @@ jobs:
         shell: bash
       - name: Compile and test jsonrpc4s
         run: |
-          sbt test
+          sbt +test
         shell: bash

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -6,3 +6,4 @@ align.openParenCallSite = false
 align.openParenDefnSite = false
 binPack.literalArgumentLists = true
 version = "2.4.2"
+project.git = true

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,6 @@
+lazy val scala212 = "2.12.14"
+lazy val scala213 = "2.13.6"
+
 inThisBuild(
   List(
     organization := "me.vican.jorge",
@@ -19,7 +22,7 @@ inThisBuild(
         url("https://jvican.github.io/")
       )
     ),
-    scalaVersion := "2.13.2",
+    scalaVersion := scala213,
     scalacOptions ++= List(
       "-Yrangepos",
       "-deprecation",
@@ -31,13 +34,15 @@ inThisBuild(
 )
 
 name := "jsonrpc4s"
+crossScalaVersions := List(scala212, scala213)
 releaseEarlyWith := SonatypePublisher
 publishTo := sonatypePublishToBundle.value
 libraryDependencies ++= List(
-  "io.monix" %% "monix" % "3.1.0",
-  "com.outr" %% "scribe" % "2.7.10",
-  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.1.15",
-  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.1.15" % Provided,
-  "io.monix" %% "minitest" % "2.7.0" % Test,
-  "com.lihaoyi" %% "pprint" % "0.5.6" % Test
+  "io.monix" %% "monix" % "3.2.0",
+  "com.outr" %% "scribe" % "3.5.5",
+  "com.outr" %% "scribe-file" % "3.5.5" % Test,
+  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.8.2",
+  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.8.2" % Provided,
+  "io.monix" %% "minitest" % "2.9.6" % Test,
+  "com.lihaoyi" %% "pprint" % "0.6.6" % Test
 )

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ crossScalaVersions := List(scala212, scala213)
 releaseEarlyWith := SonatypePublisher
 publishTo := sonatypePublishToBundle.value
 libraryDependencies ++= List(
-  "io.monix" %% "monix" % "3.4.0",
+  "io.monix" %% "monix" % "3.2.0",
   "com.outr" %% "scribe" % "3.5.5",
   "com.outr" %% "scribe-file" % "3.5.5" % Test,
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.8.2",

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ crossScalaVersions := List(scala212, scala213)
 releaseEarlyWith := SonatypePublisher
 publishTo := sonatypePublishToBundle.value
 libraryDependencies ++= List(
-  "io.monix" %% "monix" % "3.2.0",
+  "io.monix" %% "monix" % "3.4.0",
   "com.outr" %% "scribe" % "3.5.5",
   "com.outr" %% "scribe-file" % "3.5.5" % Test,
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.8.2",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.5.3

--- a/src/test/scala/jsonrpc4s/tests/FileLoggerSuite.scala
+++ b/src/test/scala/jsonrpc4s/tests/FileLoggerSuite.scala
@@ -5,12 +5,14 @@ import java.io.PrintStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import minitest.SimpleTestSuite
+import scribe.file.FileWriter
 
 object FileLoggerSuite extends SimpleTestSuite {
   test("logs don't go to stdout") {
     val path = Files.createTempFile("lsp4s", ".log")
     val baos = new ByteArrayOutputStream()
-    val writer = scribe.writer.FileWriter().path(_ => path).autoFlush
+
+    val writer = new FileWriter(path).flushAlways
     Console.withOut(new PrintStream(baos)) {
       val logger = scribe.Logger("lsp4s").orphan().withHandler(writer = writer)
       logger.info("This is info")

--- a/src/test/scala/jsonrpc4s/tests/ServicesSuite.scala
+++ b/src/test/scala/jsonrpc4s/tests/ServicesSuite.scala
@@ -16,5 +16,6 @@ object ServicesSuite extends SimpleTestSuite {
     intercept[IllegalArgumentException] {
       base.notification(duplicate)(_ => ())
     }
+    ()
   }
 }


### PR DESCRIPTION
So while working on https://github.com/build-server-protocol/build-server-protocol/pull/175 I started to dig into here to see what could be going on and I realized this had some commits that haven't been published yet. Using the latest here I actually finally get past the `initialize` and it stops timing out. I'm not sure what exact commit fixed that part, but it works. I've gone through and updated the deps to the latest except for Monix, which introduces an odd test failure I didn't dig too much into. Let me know if I changed anything you want changed back or took out anything that was actually needed. I also added cross-building in for 2.12/2.13.