### PR TITLE
fix error response serialization for newer versions of jsoniter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,8 +41,8 @@ libraryDependencies ++= List(
   "io.monix" %% "monix" % "3.2.0",
   "com.outr" %% "scribe" % "3.5.5",
   "com.outr" %% "scribe-file" % "3.5.5" % Test,
-  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.8.2",
-  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.8.2" % Provided,
+  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.10.4",
+  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.10.4" % Provided,
   "io.monix" %% "minitest" % "2.9.6" % Test,
   "com.lihaoyi" %% "pprint" % "0.6.6" % Test
 )

--- a/src/main/scala/jsonrpc4s/Message.scala
+++ b/src/main/scala/jsonrpc4s/Message.scala
@@ -11,7 +11,7 @@ import java.nio.ByteBuffer
 import java.nio.channels.Channels
 import java.nio.channels.WritableByteChannel
 
-import com.github.plokhotnyuk.jsoniter_scala.core.writeToString
+import com.github.plokhotnyuk.jsoniter_scala.core.writeToStringReentrant
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
 import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 import com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig
@@ -291,7 +291,7 @@ object Response {
     implicit val errorCodec: JsonValueCodec[StringifiedError] =
       JsonCodecMaker.make(CodecMakerConfig.withTransientDefault(false))
     val err = StringifiedError(id, error, headers)
-    writeToString(err, config = WriterConfig.withIndentionStep(4))
+    writeToStringReentrant(err, config = WriterConfig.withIndentionStep(4))
   }
 
   implicit val errorCodec: JsonValueCodec[Error] =

--- a/src/test/scala/jsonrpc4s/tests/MessageCodecSuite.scala
+++ b/src/test/scala/jsonrpc4s/tests/MessageCodecSuite.scala
@@ -1,0 +1,27 @@
+package jsonrpc4s.tests
+
+import minitest.SimpleTestSuite
+import jsonrpc4s._
+import com.github.plokhotnyuk.jsoniter_scala.core.{readFromArray, writeToArray}
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+import com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig
+
+object MessageCodecSuite extends SimpleTestSuite {
+
+  def check(testName: String, message: Message): Unit = {
+    test(testName) {
+      val obtained = readFromArray[Message](writeToArray(message))
+      assertEquals(obtained, message)
+    }
+  }
+
+  check("Request", Request("method", Some(RawJson("1".getBytes)), RequestId(1), Map.empty))
+  check("Notification", Notification("method", Some(RawJson("2".getBytes)), Map.empty))
+  check("Response.Success", Response.Success(RawJson("3".getBytes), RequestId(2)))
+  check(
+    "Response.Error",
+    Response
+      .Error(ErrorObject(ErrorCode.ParseError, "method", Some(RawJson("4".getBytes))), RequestId(3))
+  )
+}


### PR DESCRIPTION
In jsoniter versions v2.10.0 and later, the `writeToString` method uses a shared instance of `JsonWriter`. This breaks the serialization of `jsonrpc4s.Response.Error`, because it invokes `writeToString` in its constructor.

Here is a scala-cli script that shows how this breaks bloop, which depends on a newer version of jsoniter
```scala
//> using scala "2.13"
//> using lib "me.vican.jorge::jsonrpc4s:0.1.0"

import java.nio.channels.Channels
import jsonrpc4s.{LowLevelChannelMessageWriter, Request, RequestId}
import scribe.Logger

val process =
  new ProcessBuilder("cs", "launch", "ch.epfl.scala:bloop-launcher-core_2.13:1.5.4", "--", "1.5.4")
    .redirectError(ProcessBuilder.Redirect.PIPE)
    .redirectOutput(ProcessBuilder.Redirect.INHERIT)
    .redirectInput(ProcessBuilder.Redirect.PIPE)
    .start()

val msg = Request(
  "foobar", // unknown method
  None,
  RequestId(1),
  Map.empty,
)

val writer = new LowLevelChannelMessageWriter(
  Channels.newChannel(process.getOutputStream),
  Logger.root,
)

writer.write(msg)
process.getOutputStream.flush()
process.getInputStream.close()

Thread.sleep(2000) // wait for response
```

The script creates a bsp server using the bloop launcher and sends a request to the non-existent bsp method "foobar". The bloop server responds with invalid json:
```json
Content-Length: 201

{
    "id": 1,
    "error": {
        "code": -32601,
        "message": "foobar"
    }
},{
    "error": {
        "code": -32601,
        "message": "foobar"
    },
    "id": 1,
    "jsonrpc": "2.0"
}
```

The expected response should be
```json
Content-Length: ???

{
    "error": {
        "code": -32601,
        "message": "foobar"
    },
    "id": 1,
    "jsonrpc": "2.0"
}
```

This PR updates jsoniter to v2.10.4 and replaces the usage of `writeToString` with `writeToStringReentrant` in the `Response.Error` constructor. `writeToStringReentrant` behaves like the old version of `writeToString` and creates a new `JsonWriter` instance each time it is called.